### PR TITLE
appveyor configuration to build on 15.3.1, 17.5, 18.3 and 19.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+version: "{build}"
+branches:
+  only:
+  - master
+environment:
+  matrix:
+  - erlang_vsn: 19.2
+  - erlang_vsn: 18.3
+  - erlang_vsn: 17.5
+  - erlang_vsn: 15.3.1
+install:
+- ps: choco install erlang --version $env:erlang_vsn
+build_script:
+- ps: cmd.exe /c 'bootstrap.bat'
+test_script:
+- ps: cmd.exe /c 'rebar3.cmd ct'
+notifications:
+- provider: GitHubPullRequest
+  on_build_success: true
+  on_build_failure: true
+  on_build_status_changed: false


### PR DESCRIPTION
16.x is not available on chocolatey